### PR TITLE
[codex] refresh projects content and freetyme details

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
       name="description"
       content="Ross McLain is a senior full stack engineer building polished product experiences and practical business software."
     />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Ross McLain | Portfolio v2</title>
   </head>
   <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="bg" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0b1020" />
+      <stop offset="1" stop-color="#1e3a8a" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)" />
+  <circle cx="50" cy="14" r="4" fill="#facc15" />
+  <text
+    x="32"
+    y="42"
+    text-anchor="middle"
+    fill="#f8fafc"
+    font-family="Georgia, 'Times New Roman', serif"
+    font-size="24"
+    font-weight="700"
+    letter-spacing="1"
+  >
+    RM
+  </text>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -22,16 +22,33 @@
   <circle cx="18" cy="52" r="1" fill="#ff3fa8" />
   <circle cx="48" cy="48" r="0.9" fill="#1ef0de" />
 
-  <text
-    x="32"
-    y="42"
-    text-anchor="middle"
-    fill="url(#teal)"
-    filter="url(#mGlow)"
-    font-family="'PressStart2P', 'IBMPlexMono', monospace"
-    font-size="24"
-    letter-spacing="0.01em"
-  >
-    M
-  </text>
+  <g fill="url(#teal)" filter="url(#mGlow)" shape-rendering="crispEdges">
+    <rect x="16" y="18" width="4" height="4" />
+    <rect x="44" y="18" width="4" height="4" />
+
+    <rect x="16" y="22" width="4" height="4" />
+    <rect x="20" y="22" width="4" height="4" />
+    <rect x="40" y="22" width="4" height="4" />
+    <rect x="44" y="22" width="4" height="4" />
+
+    <rect x="16" y="26" width="4" height="4" />
+    <rect x="24" y="26" width="4" height="4" />
+    <rect x="36" y="26" width="4" height="4" />
+    <rect x="44" y="26" width="4" height="4" />
+
+    <rect x="16" y="30" width="4" height="4" />
+    <rect x="28" y="30" width="4" height="4" />
+    <rect x="32" y="30" width="4" height="4" />
+    <rect x="44" y="30" width="4" height="4" />
+
+    <rect x="16" y="34" width="4" height="4" />
+    <rect x="32" y="34" width="4" height="4" />
+    <rect x="44" y="34" width="4" height="4" />
+
+    <rect x="16" y="38" width="4" height="4" />
+    <rect x="44" y="38" width="4" height="4" />
+
+    <rect x="16" y="42" width="4" height="4" />
+    <rect x="44" y="42" width="4" height="4" />
+  </g>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -9,14 +9,14 @@
   <circle cx="50" cy="14" r="4" fill="#facc15" />
   <text
     x="32"
-    y="42"
+    y="44"
     text-anchor="middle"
     fill="#f8fafc"
     font-family="Georgia, 'Times New Roman', serif"
-    font-size="24"
+    font-size="34"
     font-weight="700"
-    letter-spacing="1"
+    letter-spacing="0"
   >
-    RM
+    M
   </text>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,21 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <defs>
-    <linearGradient id="bg" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#0b1020" />
-      <stop offset="1" stop-color="#1e3a8a" />
+    <radialGradient id="space" cx="24%" cy="18%" r="86%">
+      <stop offset="0%" stop-color="#0f1f24" />
+      <stop offset="42%" stop-color="#070c0e" />
+      <stop offset="100%" stop-color="#030405" />
+    </radialGradient>
+    <linearGradient id="teal" x1="14" y1="12" x2="50" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#b5f7ef" />
+      <stop offset="48%" stop-color="#1ef0de" />
+      <stop offset="100%" stop-color="#03c7b5" />
     </linearGradient>
+    <filter id="mGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="1.4" flood-color="#1ef0de" flood-opacity="0.8" />
+      <feDropShadow dx="0" dy="0" stdDeviation="2.6" flood-color="#03c7b5" flood-opacity="0.45" />
+    </filter>
   </defs>
-  <rect width="64" height="64" rx="14" fill="url(#bg)" />
-  <circle cx="50" cy="14" r="4" fill="#facc15" />
+
+  <rect width="64" height="64" rx="14" fill="url(#space)" />
+  <circle cx="14" cy="11" r="1.3" fill="#e5fffb" />
+  <circle cx="52" cy="14" r="1.1" fill="#b5f7ef" />
+  <circle cx="18" cy="52" r="1" fill="#ff3fa8" />
+  <circle cx="48" cy="48" r="0.9" fill="#1ef0de" />
+
   <text
     x="32"
-    y="44"
+    y="42"
     text-anchor="middle"
-    fill="#f8fafc"
-    font-family="Georgia, 'Times New Roman', serif"
-    font-size="34"
-    font-weight="700"
-    letter-spacing="0"
+    fill="url(#teal)"
+    filter="url(#mGlow)"
+    font-family="'PressStart2P', 'IBMPlexMono', monospace"
+    font-size="24"
+    letter-spacing="0.01em"
   >
     M
   </text>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -5,6 +5,14 @@
       <stop offset="42%" stop-color="#070c0e" />
       <stop offset="100%" stop-color="#030405" />
     </radialGradient>
+    <radialGradient id="nebulaA" cx="18%" cy="12%" r="55%">
+      <stop offset="0%" stop-color="#1ef0de" stop-opacity="0.24" />
+      <stop offset="100%" stop-color="#1ef0de" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="nebulaB" cx="84%" cy="84%" r="60%">
+      <stop offset="0%" stop-color="#ff3fa8" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#ff3fa8" stop-opacity="0" />
+    </radialGradient>
     <linearGradient id="teal" x1="14" y1="12" x2="50" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#b5f7ef" />
       <stop offset="48%" stop-color="#1ef0de" />
@@ -17,38 +25,57 @@
   </defs>
 
   <rect width="64" height="64" rx="14" fill="url(#space)" />
-  <circle cx="14" cy="11" r="1.3" fill="#e5fffb" />
-  <circle cx="52" cy="14" r="1.1" fill="#b5f7ef" />
-  <circle cx="18" cy="52" r="1" fill="#ff3fa8" />
-  <circle cx="48" cy="48" r="0.9" fill="#1ef0de" />
+  <rect width="64" height="64" rx="14" fill="url(#nebulaA)" />
+  <rect width="64" height="64" rx="14" fill="url(#nebulaB)" />
+
+  <g shape-rendering="crispEdges">
+    <rect x="7" y="9" width="2" height="2" fill="#e5fffb" fill-opacity="0.8" />
+    <rect x="13" y="6" width="1" height="1" fill="#b5f7ef" fill-opacity="0.55" />
+    <rect x="21" y="10" width="1" height="1" fill="#1ef0de" fill-opacity="0.45" />
+    <rect x="29" y="7" width="1" height="1" fill="#e5fffb" fill-opacity="0.6" />
+    <rect x="39" y="10" width="1" height="1" fill="#1ef0de" fill-opacity="0.4" />
+    <rect x="49" y="8" width="2" height="2" fill="#b5f7ef" fill-opacity="0.72" />
+    <rect x="56" y="13" width="1" height="1" fill="#ff3fa8" fill-opacity="0.5" />
+
+    <rect x="9" y="18" width="1" height="1" fill="#1ef0de" fill-opacity="0.42" />
+    <rect x="54" y="20" width="1" height="1" fill="#e5fffb" fill-opacity="0.62" />
+    <rect x="4" y="27" width="1" height="1" fill="#b5f7ef" fill-opacity="0.48" />
+    <rect x="59" y="30" width="1" height="1" fill="#1ef0de" fill-opacity="0.52" />
+    <rect x="8" y="38" width="1" height="1" fill="#ff3fa8" fill-opacity="0.4" />
+    <rect x="55" y="42" width="1" height="1" fill="#e5fffb" fill-opacity="0.58" />
+    <rect x="15" y="55" width="2" height="2" fill="#ff3fa8" fill-opacity="0.6" />
+    <rect x="25" y="58" width="1" height="1" fill="#b5f7ef" fill-opacity="0.46" />
+    <rect x="35" y="56" width="1" height="1" fill="#1ef0de" fill-opacity="0.42" />
+    <rect x="45" y="59" width="1" height="1" fill="#e5fffb" fill-opacity="0.5" />
+    <rect x="53" y="54" width="2" height="2" fill="#1ef0de" fill-opacity="0.55" />
+  </g>
 
   <g fill="url(#teal)" filter="url(#mGlow)" shape-rendering="crispEdges">
-    <rect x="16" y="18" width="4" height="4" />
-    <rect x="44" y="18" width="4" height="4" />
+    <rect x="16" y="16" width="4" height="4" />
+    <rect x="44" y="16" width="4" height="4" />
 
-    <rect x="16" y="22" width="4" height="4" />
-    <rect x="20" y="22" width="4" height="4" />
-    <rect x="40" y="22" width="4" height="4" />
-    <rect x="44" y="22" width="4" height="4" />
+    <rect x="16" y="20" width="4" height="4" />
+    <rect x="20" y="20" width="4" height="4" />
+    <rect x="40" y="20" width="4" height="4" />
+    <rect x="44" y="20" width="4" height="4" />
 
-    <rect x="16" y="26" width="4" height="4" />
-    <rect x="24" y="26" width="4" height="4" />
-    <rect x="36" y="26" width="4" height="4" />
-    <rect x="44" y="26" width="4" height="4" />
+    <rect x="16" y="24" width="4" height="4" />
+    <rect x="24" y="24" width="4" height="4" />
+    <rect x="36" y="24" width="4" height="4" />
+    <rect x="44" y="24" width="4" height="4" />
 
-    <rect x="16" y="30" width="4" height="4" />
-    <rect x="28" y="30" width="4" height="4" />
-    <rect x="32" y="30" width="4" height="4" />
-    <rect x="44" y="30" width="4" height="4" />
+    <rect x="16" y="28" width="4" height="4" />
+    <rect x="28" y="28" width="4" height="4" />
+    <rect x="32" y="28" width="4" height="4" />
+    <rect x="44" y="28" width="4" height="4" />
 
-    <rect x="16" y="34" width="4" height="4" />
-    <rect x="32" y="34" width="4" height="4" />
-    <rect x="44" y="34" width="4" height="4" />
-
-    <rect x="16" y="38" width="4" height="4" />
-    <rect x="44" y="38" width="4" height="4" />
-
-    <rect x="16" y="42" width="4" height="4" />
-    <rect x="44" y="42" width="4" height="4" />
+    <rect x="16" y="32" width="4" height="4" />
+    <rect x="44" y="32" width="4" height="4" />
+    <rect x="16" y="36" width="4" height="4" />
+    <rect x="44" y="36" width="4" height="4" />
+    <rect x="16" y="40" width="4" height="4" />
+    <rect x="44" y="40" width="4" height="4" />
+    <rect x="16" y="44" width="4" height="4" />
+    <rect x="44" y="44" width="4" height="4" />
   </g>
 </svg>

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -164,8 +164,4 @@ export const techLens = [
   "UX-first full-stack delivery"
 ];
 
-export const resumeHighlights = [
-  "Built and led multi-year product initiatives across full-stack systems.",
-  "Balanced IC delivery with team leadership and mentoring responsibilities.",
-  "Strong track record modernizing legacy experiences into scalable products."
-];
+export const resumeHighlights: string[] = [];

--- a/src/pages/LabsPage.tsx
+++ b/src/pages/LabsPage.tsx
@@ -14,7 +14,6 @@ export const LabsPage = () => {
       <section className="section-spacing">
         <header className="section-header">
           <p className="section-label">LABS</p>
-          <h1>Interactive projects</h1>
           <p className="section-intro">
             Labs is where I share interactive projects and experiments.
           </p>

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -16,7 +16,6 @@ export const ResumePage = () => {
       <section className="section-spacing">
         <header className="section-header">
           <p className="section-label">RESUME</p>
-          <h1>Current resume</h1>
         </header>
         {resumeHighlights.length > 0 ? (
           <ul className="outcomes-list">

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -16,7 +16,7 @@ export const ResumePage = () => {
       <section className="section-spacing">
         <header className="section-header">
           <p className="section-label">RESUME</p>
-          <h1>Current resume and quick highlights</h1>
+          <h1>Current resume</h1>
         </header>
         <ul className="outcomes-list">
           {resumeHighlights.map((item) => (

--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -18,11 +18,13 @@ export const ResumePage = () => {
           <p className="section-label">RESUME</p>
           <h1>Current resume</h1>
         </header>
-        <ul className="outcomes-list">
-          {resumeHighlights.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+        {resumeHighlights.length > 0 ? (
+          <ul className="outcomes-list">
+            {resumeHighlights.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : null}
         <a className="primary-button mt-4" href={siteMeta.resumePath} download>
           <Download size={16} />
           Download Resume

--- a/src/pages/WorkPage.tsx
+++ b/src/pages/WorkPage.tsx
@@ -47,14 +47,6 @@ export const WorkPage = () => {
   return (
     <>
       <section className="section-spacing">
-        <header className="section-header">
-          <p className="section-label">PORTFOLIO</p>
-          <h1>Featured case studies and archive</h1>
-          <p className="section-intro">
-            Filter by technology to surface relevant builds quickly.
-          </p>
-        </header>
-
         <div className="filter-row">
           {tags.map((tag) => {
             const selected = selectedTags.includes(tag);

--- a/src/pages/WorkPage.tsx
+++ b/src/pages/WorkPage.tsx
@@ -47,6 +47,9 @@ export const WorkPage = () => {
   return (
     <>
       <section className="section-spacing">
+        <header className="section-header">
+          <p className="section-label">PORTFOLIO</p>
+        </header>
         <div className="filter-row">
           {tags.map((tag) => {
             const selected = selectedTags.includes(tag);


### PR DESCRIPTION
## Summary
- Refreshes the `/work` experience to present the section as Projects and removes the standalone Decyde entry.
- Updates the Freetyme case study to reflect the current product details, stack, and public link.
- Adds a regression test to keep the Freetyme card summary and stack metadata aligned.

## Related Issues
- Relates to [MCL-124](https://linear.app/mclaindev/issue/MCL-124/update-text-on-httpsmclaindevelopmentcomwork)

## Changes
- Renamed user-facing `Work` labels to `Projects` in navigation and project views while keeping the `/work` route intact.
- Removed the `decyde` project entry from the MDX-backed project content.
- Updated `Freetyme` to 2026, pointed it at `https://freetyme.app`, removed the private repo link, and rewrote the copy around group scheduling and companion apps.
- Corrected the Freetyme tech tags from `Next.js` and `PostgreSQL` to `Vite` and `Convex`.
- Added a focused test that guards the Freetyme summary and tech stack metadata.

## Type of Change
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (code change without feature/fix)
- [ ] perf (performance improvement)
- [ ] docs (documentation only)
- [x] test (tests added/updated)
- [ ] chore (maintenance)

## PR Size & Scope
- [x] Small (<100 lines, straightforward)
- [ ] Medium (100–500 lines, moderate complexity)
- [ ] Large (>500 lines or complex)

## How to Test
- Run `npm test -- src/content/freetyme-content.test.ts`.
- Run `npm run build`.
- Visit `/work` and confirm the nav and section language now says `Projects`.
- Confirm the Freetyme card no longer says `alpha` in the summary and shows `Vite` and `Convex` in its stack tags.

## Screenshots / Recordings
- N/A

## Breaking Changes
- None

## Rollout Plan
- [x] Safe to release immediately
- [ ] Requires feature flag
- [ ] Requires staged rollout
- Roll back by reverting commit `4c3f9e6` if the project content needs to be restored.

## Monitoring & Observability
- N/A

## Additional Context
- The visible section language now uses `Projects`, but routes remain under `/work` to preserve existing links and routing behavior.
